### PR TITLE
Adding features to enable default account setting in account.blackbaud.com

### DIFF
--- a/data/salesforce/contact.go
+++ b/data/salesforce/contact.go
@@ -73,7 +73,7 @@ func (a API) GetByAuthID(id string) (string, error) {
 
 	query := "SELECT Id, Salutation, FirstName, LastName, Email, Phone, Fax, Title, AccountId, AccountName__c," +
 		"SFDC_Contact_Status__c, CurrencyIsoCode, BBAuthID__c, BBAuth_Email__c, BBAuth_First_Name__c," +
-		"BBAuth_Last_Name__c, Account.Name, Account.Id, Account.Clarify_Site_ID__c," +
+		"BBAuth_Last_Name__c, Default_Account__c, Account.Name, Account.Id, Account.Clarify_Site_ID__c," +
 		"Account.Business_unit__c, Account.Industry, Account.Payer__c," +
 		"Account.Billing_street__c, Account.Billing_City__c, Account.Billing_State_Province__c," +
 		"Account.Billing_Zip_Postal_Code__c, Account.Billing_Country__c," +
@@ -95,7 +95,7 @@ func (a API) GetByEmail(email string) (string, error) {
 
 	query := "SELECT Id, Salutation, FirstName, LastName, Email, Phone, Fax, Title, AccountId, AccountName__c," +
 		"SFDC_Contact_Status__c, CurrencyIsoCode, BBAuthID__c, BBAuth_Email__c, BBAuth_First_Name__c," +
-		"BBAuth_Last_Name__c, Account.Name, Account.Id, Account.Clarify_Site_ID__c," +
+		"BBAuth_Last_Name__c, Default_Account__c, Account.Name, Account.Id, Account.Clarify_Site_ID__c," +
 		"Account.Business_unit__c, Account.Industry, Account.Payer__c," +
 		"Account.Billing_street__c, Account.Billing_City__c, Account.Billing_State_Province__c," +
 		"Account.Billing_Zip_Postal_Code__c, Account.Billing_Country__c," +

--- a/data/salesforce/contact.go
+++ b/data/salesforce/contact.go
@@ -106,6 +106,22 @@ func (a API) GetByEmail(email string) (string, error) {
 	return query, nil
 }
 
+//GetByIDs returns a contact query string that selects contacts with the given
+//SFDC IDs.
+func (a API) GetByIDs(ids []string) (string, error) {
+	query := "SELECT Id, Salutation, FirstName, LastName, Email, Phone, Fax, Title, AccountId, AccountName__c," +
+		"SFDC_Contact_Status__c, CurrencyIsoCode, BBAuthID__c, BBAuth_Email__c, BBAuth_First_Name__c," +
+		"BBAuth_Last_Name__c, Default_Account__c, Account.Name, Account.Id, Account.Clarify_Site_ID__c," +
+		"Account.Business_unit__c, Account.Industry, Account.Payer__c," +
+		"Account.Billing_street__c, Account.Billing_City__c, Account.Billing_State_Province__c," +
+		"Account.Billing_Zip_Postal_Code__c, Account.Billing_Country__c," +
+		"Account.Physical_Street__c, Account.Physical_City__c, Account.Physical_State_Province__c," +
+		"Account.Physical_Zip_Postal_Code__c, Account.Physical_Country__c FROM Contact " +
+		"WHERE Id in " + parseIDs(ids)
+
+	return query, nil
+}
+
 //UpdateContact updates a given contact.
 func (a API) UpdateContact(contact *services.ContactDTO) error {
 	//This is a bit weird, but we can't update a record if the ID is part of the
@@ -119,4 +135,18 @@ func (a API) UpdateContact(contact *services.ContactDTO) error {
 	sfdcContact.Account = nil
 
 	return a.client.UpdateSFDCObject(id, sfdcContact)
+}
+
+func parseIDs(ids []string) string {
+	idCSV := "("
+
+	for index, id := range ids {
+		if index == 0 {
+			idCSV += fmt.Sprintf("'%s'", id)
+		} else {
+			idCSV += fmt.Sprintf(", '%s'", id)
+		}
+	}
+	idCSV += ")"
+	return idCSV
 }

--- a/data/salesforce/contact_test.go
+++ b/data/salesforce/contact_test.go
@@ -133,6 +133,19 @@ func TestGetByEmail(t *testing.T) {
 	})
 }
 
+func TestGetByIDs(t *testing.T) {
+	Convey("Given a list of IDs", t, func() {
+		ids := []string{"1234", "5678"}
+		Convey("When requesting a contact query string", func() {
+			query, err := api.GetByIDs(ids)
+			Convey("Then a query string should be returned", func() {
+				So(query, ShouldNotBeEmpty)
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}
+
 func TestUpdateContact(t *testing.T) {
 	Convey("Given a valid contactDTO", t, func() {
 		contact := &services.ContactDTO{SalesForceID: "12345", LastName: "Tate", Currency: "USD - U.S. Dollar"}

--- a/entities/contact.go
+++ b/entities/contact.go
@@ -14,6 +14,7 @@ type Contact struct {
 	Fax             string
 	Title           string
 	account         *Account
+	defaultAccount  string
 	status          string
 	Currency        CurrencyType
 	bbAuthID        string
@@ -95,6 +96,11 @@ func (c *Contact) Account() *Account {
 	return c.account
 }
 
+//DefaultAccount of the contact.
+func (c *Contact) DefaultAccount() string {
+	return c.defaultAccount
+}
+
 //Status of the cotnact.
 func (c *Contact) Status() string {
 	return c.status
@@ -135,6 +141,12 @@ func (c *Contact) SetEmail(email string) error {
 //SetAccount sets the contact's account.
 func (c *Contact) SetAccount(account *Account) error {
 	c.account = account
+	return nil
+}
+
+//SetDefaultAccount sets the contact's default account.
+func (c *Contact) SetDefaultAccount(id string) error {
+	c.defaultAccount = id
 	return nil
 }
 

--- a/entities/contact_test.go
+++ b/entities/contact_test.go
@@ -14,6 +14,7 @@ var contactEntity = &Contact{
 	Fax:             "(843)654-2566",
 	Title:           "Application Developer II",
 	account:         &Account{name: "Test Account"},
+	defaultAccount:  "123",
 	status:          "Active",
 	Currency:        "USD - U.S. Dollar",
 	bbAuthID:        "123456-1234-1234-1234-12345678",
@@ -93,6 +94,12 @@ func TestContactGettersAndSetters(t *testing.T) {
 				So(account, ShouldNotBeNil)
 			})
 		})
+		Convey("When requesting their default account", func() {
+			defaultAccount := contact.DefaultAccount()
+			Convey("Then a default account ID should be returned.", func() {
+				So(defaultAccount, ShouldNotBeEmpty)
+			})
+		})
 		Convey("When requesting their status", func() {
 			status := contact.Status()
 			Convey("Then a status should be returned.", func() {
@@ -142,6 +149,13 @@ func TestContactGettersAndSetters(t *testing.T) {
 			contact.SetAccount(account)
 			Convey("Then the contact's account should be changed", func() {
 				So(contact.Account(), ShouldEqual, account)
+			})
+		})
+		Convey("When attempting to set their default account", func() {
+			defaultAccount := "123456"
+			contact.SetDefaultAccount(defaultAccount)
+			Convey("Then the contact's default account should be changed", func() {
+				So(contact.DefaultAccount(), ShouldEqual, defaultAccount)
 			})
 		})
 		Convey("When attempting to set their status", func() {

--- a/examples/server.go
+++ b/examples/server.go
@@ -16,13 +16,26 @@ func main() {
 	fmt.Println("starting...")
 	fmt.Println("")
 
-	updateContactExample()
+	getContactsByIDsExample()
+	//updateContactExample()
 	//getContactsWithAccountExample()
 	//getContactCountExample()
 	//getContactExample()
 	//getAccountExample()
 	//insertAccountExample()
 	//updateAccountExample()
+}
+
+func getContactsByIDsExample() {
+	ids := []string{"00355000006LpSuAAK", "003d0000026MOlUAAW", "00355000006LvFMAA0"}
+
+	contactDTOs, err := contactService.GetContactsByIDs(ids)
+
+	fmt.Println(err)
+
+	data, _ := json.Marshal(contactDTOs)
+
+	fmt.Printf("Contacts: %s", data)
 }
 
 func updateContactExample() {

--- a/services/contactservice.go
+++ b/services/contactservice.go
@@ -33,6 +33,7 @@ type ContactDTO struct {
 	Fax             string      `json:"fax,omitempty" force:"Fax,omitempty"`
 	Title           string      `json:"title,omitempty" force:"Title,omitempty"`
 	Account         *AccountDTO `json:"account,omitempty" force:"Account,omitempty"`
+	DefaultAccount  string      `json:"defaultAccount,omitempty" force:"Default_Account__c,omitempty"`
 	Status          string      `json:"status,omitempty" force:"SFDC_Contact_Status__c,omitempty"`
 	Currency        string      `json:"currency,omitempty" force:"CurrencyIsoCode"`
 	BBAuthID        string      `json:"bbAuthId,omitempty" force:"BBAuthID__c,omitempty"`
@@ -70,6 +71,7 @@ func (c *ContactDTO) ToEntity() (*entities.Contact, error) {
 	contact.Fax = c.Fax
 	contact.Title = c.Title
 	contact.SetID(c.SalesForceID)
+	contact.SetDefaultAccount(c.DefaultAccount)
 	contact.SetEmail(c.Email)
 	contact.SetStatus(c.Status)
 	contact.SetBBAuthID(c.BBAuthID)
@@ -93,6 +95,7 @@ func ConvertContactEntityToContactDTO(contact *entities.Contact) *ContactDTO {
 		Fax:             contact.Fax,
 		Title:           contact.Title,
 		Account:         ConvertAccountEntityToAccountDTO(contact.Account()),
+		DefaultAccount:  contact.DefaultAccount(),
 		Status:          contact.Status(),
 		BBAuthID:        contact.BBAuthID(),
 		BBAuthEmail:     contact.BBAuthEmail(),

--- a/services/contactservice.go
+++ b/services/contactservice.go
@@ -19,6 +19,7 @@ type ContactRepository interface {
 type ContactQueryBuilder interface {
 	GetByAuthID(id string) (string, error)
 	GetByEmail(email string) (string, error)
+	GetByIDs(ids []string) (string, error)
 }
 
 //ContactDTO is a data transfer object for entities.Contact
@@ -143,6 +144,19 @@ func (cs *ContactService) GetContactsByAuthID(authID string) ([]*ContactDTO, err
 	if err != nil {
 		return make([]*ContactDTO, 0), err
 	}
+	contacts, err := cs.ContactRepo.QueryContacts(query)
+
+	return contacts, err
+}
+
+//GetContactsByIDs returns all contact records associated with the given IDs.
+func (cs *ContactService) GetContactsByIDs(ids []string) ([]*ContactDTO, error) {
+	query, err := cs.ContactRepo.GetByIDs(ids)
+
+	if err != nil {
+		return make([]*ContactDTO, 0), err
+	}
+
 	contacts, err := cs.ContactRepo.QueryContacts(query)
 
 	return contacts, err

--- a/services/contactservices_test.go
+++ b/services/contactservices_test.go
@@ -68,6 +68,14 @@ func (m mockContactRepository) GetByEmail(email string) (string, error) {
 	return "", errors.New("Must provide a valid email address")
 }
 
+func (m mockContactRepository) GetByIDs(ids []string) (string, error) {
+	if len(ids) > 0 {
+		return "success!", nil
+	}
+
+	return "", errors.New("Must provide a slice of IDs")
+}
+
 func TestContactDTOToEntity(t *testing.T) {
 	Convey("Given a Contact Data Transfer object with an empty last name", t, func() {
 		contactDTOCopy := contactDTO
@@ -209,6 +217,30 @@ func TestGetContactsByAuthID(t *testing.T) {
 	})
 }
 
+func TestGetContactsByIDs(t *testing.T) {
+	Convey("Given a list of IDs", t, func() {
+		ids := []string{"1234", "5678"}
+		Convey("when a list of contacts are queried", func() {
+			cs := NewContactService(mockContactRepository{})
+			contacts, err := cs.GetContactsByIDs(ids)
+			Convey("A list of contacts should be returned", func() {
+				So(contacts, ShouldNotBeEmpty)
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+	Convey("Given a blank list of IDs", t, func() {
+		ids := []string{}
+		Convey("When a list of contacts are qeried", func() {
+			cs := NewContactService(mockContactRepository{})
+			contacts, err := cs.GetContactsByIDs(ids)
+			Convey("An error should occur and no contacts should be returned", func() {
+				So(contacts, ShouldBeEmpty)
+				So(err, ShouldNotBeNil)
+			})
+		})
+	})
+}
 func TestQueryContactsByAuthID(t *testing.T) {
 	Convey("Given a contact query string", t, func() {
 		query := "success!"


### PR DESCRIPTION
To allow for setting default accounts on contact sObjects, I added the new DefaultAccount field to all contact queries. I also added a GetContactsByIDs function. It takes a slice of IDs and converts them into a proper query string for retrieving a list of contacts with a list of contact IDs. 