### PR TITLE
Add contact roles

### DIFF
--- a/data/salesforce/contact.go
+++ b/data/salesforce/contact.go
@@ -11,21 +11,13 @@ import (
 //SFDCContact wraps the ContactDTO so that SFDC fields can be mapped onto it.
 type SFDCContact struct {
 	services.ContactDTO
-	ContactRoles SFDCContactRoleQueryResponse `force:"Contact_Roles1__r,omitempty"`
 }
 
 //SFDCContactQueryResponse wraps the base SFDCQueryResponse and attaches a slice of SFDCContact pointers which will be written into.
 type SFDCContactQueryResponse struct {
 	SFDCQueryResponse
 
-	Records []*SFDCContact `json:"Records" force:"records"`
-}
-
-//SFDCContactRoleQueryResponse wraps the base SFDCQueryResponse and attaches a slice of services.ContactRoleDTO pointers to be written to.
-type SFDCContactRoleQueryResponse struct {
-	SFDCQueryResponse
-
-	Records []*services.ContactRoleDTO `json:"Records" force:"records"`
+	Records []*services.ContactDTO `json:"Records" force:"records"`
 }
 
 //ApiName is the SFDC ApiName of the Contact object.
@@ -67,12 +59,7 @@ func (a API) QueryContacts(query string) ([]*services.ContactDTO, error) {
 
 	err := a.client.QuerySFDCObject(query, queryResponse)
 
-	contacts := make([]*services.ContactDTO, len(queryResponse.Records))
-	for key, contact := range queryResponse.Records {
-		contacts[key] = convertSFDCContactToDTO(contact)
-	}
-
-	return contacts, err
+	return queryResponse.Records, err
 }
 
 //GetByAuthID returns a contact query string that selects contacts with the given
@@ -149,6 +136,7 @@ func (a API) UpdateContact(contact *services.ContactDTO) error {
 	id := sfdcContact.SalesForceID
 	sfdcContact.SalesForceID = ""
 	sfdcContact.Account = nil
+	sfdcContact.ContactRoles = nil
 
 	return a.client.UpdateSFDCObject(id, sfdcContact)
 }
@@ -167,9 +155,9 @@ func parseIDs(ids []string) string {
 	return idCSV
 }
 
-func convertSFDCContactToDTO(contact *SFDCContact) *services.ContactDTO {
+/*func convertSFDCContactToDTO(contact *SFDCContact) *services.ContactDTO {
 	contactDTO := &contact.ContactDTO
 	contactDTO.ContactRoles = contact.ContactRoles.Records
 
 	return contactDTO
-}
+}*/

--- a/entities/contact.go
+++ b/entities/contact.go
@@ -15,6 +15,7 @@ type Contact struct {
 	Title           string
 	account         *Account
 	defaultAccount  string
+	roles           []ContactRole
 	status          string
 	Currency        CurrencyType
 	bbAuthID        string
@@ -23,8 +24,12 @@ type Contact struct {
 	bbAuthLastName  string
 }
 
-//CurrencyType is an enum for setting a contact's preferred currency.
-type CurrencyType string
+//ContactRole is a role for a Blackbaud Contact entity.
+type ContactRole struct {
+	RoleName   string
+	RoleType   string
+	RoleStatus string
+}
 
 //Name represents the salutation, first name, and last name of a contact.
 type Name struct {
@@ -54,6 +59,9 @@ func (n *Name) SetLastName(lastName string) error {
 	n.lastName = lastName
 	return nil
 }
+
+//CurrencyType is an enum for setting a contact's preferred currency.
+type CurrencyType string
 
 //Enumeration for CurrencyType.
 const (

--- a/entities/contact.go
+++ b/entities/contact.go
@@ -15,7 +15,7 @@ type Contact struct {
 	Title           string
 	account         *Account
 	defaultAccount  string
-	roles           []ContactRole
+	roles           []*ContactRole
 	status          string
 	Currency        CurrencyType
 	bbAuthID        string
@@ -114,6 +114,11 @@ func (c *Contact) Status() string {
 	return c.status
 }
 
+//Roles of the contact.
+func (c *Contact) Roles() []*ContactRole {
+	return c.roles
+}
+
 //BBAuthID of the contact.
 func (c *Contact) BBAuthID() string {
 	return c.bbAuthID
@@ -161,6 +166,12 @@ func (c *Contact) SetDefaultAccount(id string) error {
 //SetStatus sets the contact's status.
 func (c *Contact) SetStatus(status string) error {
 	c.status = status
+	return nil
+}
+
+//SetRoles sets the contact's roles.
+func (c *Contact) SetRoles(roles []*ContactRole) error {
+	c.roles = roles
 	return nil
 }
 

--- a/entities/contact_test.go
+++ b/entities/contact_test.go
@@ -14,6 +14,7 @@ var contactEntity = &Contact{
 	Fax:             "(843)654-2566",
 	Title:           "Application Developer II",
 	account:         &Account{name: "Test Account"},
+	roles:           []*ContactRole{&ContactRole{}},
 	defaultAccount:  "123",
 	status:          "Active",
 	Currency:        "USD - U.S. Dollar",
@@ -106,6 +107,12 @@ func TestContactGettersAndSetters(t *testing.T) {
 				So(status, ShouldNotBeEmpty)
 			})
 		})
+		Convey("When requesting their roles", func() {
+			roles := contact.Roles()
+			Convey("Then a slice of roles should be returned.", func() {
+				So(roles, ShouldNotBeEmpty)
+			})
+		})
 		Convey("When requesting their bbAuthID", func() {
 			authID := contact.BBAuthID()
 			Convey("Then a BBAuthID should be returned", func() {
@@ -163,6 +170,13 @@ func TestContactGettersAndSetters(t *testing.T) {
 			contact.SetStatus(status)
 			Convey("Then the contact's status should be changed", func() {
 				So(contact.Status(), ShouldEqual, status)
+			})
+		})
+		Convey("When attempting to set their roles", func() {
+			roles := []*ContactRole{&ContactRole{RoleName: "Test"}}
+			contact.SetRoles(roles)
+			Convey("Then the contact's roles should be changed", func() {
+				So(contact.Roles()[0], ShouldEqual, roles[0])
 			})
 		})
 		Convey("When attempting to set their BBAuthID", func() {

--- a/examples/server.go
+++ b/examples/server.go
@@ -27,11 +27,9 @@ func main() {
 }
 
 func getContactsByIDsExample() {
-	ids := []string{"00355000006LpSuAAK", "003d0000026MOlUAAW", "00355000006LvFMAA0"}
+	ids := []string{"003d0000026MOlUAAW"} //, "00355000006LpSuAAK", "00355000006LvFMAA0"}
 
-	contactDTOs, err := contactService.GetContactsByIDs(ids)
-
-	fmt.Println(err)
+	contactDTOs, _ := contactService.GetContactsByIDs(ids)
 
 	data, _ := json.Marshal(contactDTOs)
 

--- a/services/contactservice.go
+++ b/services/contactservice.go
@@ -25,23 +25,29 @@ type ContactQueryBuilder interface {
 //ContactDTO is a data transfer object for entities.Contact
 type ContactDTO struct {
 	//AccountName       string `json:"accountName,omitempty" force:"AccountName__c,omitempty"`
-	Salutation      string            `json:"salutation,omitempty" force:"Salutation,omitempty"`
-	FirstName       string            `json:"firstName,omitempty" force:"FirstName,omitempty"`
-	LastName        string            `json:"lastName,omitempty" force:"LastName,omitempty"`
-	SalesForceID    string            `json:"salesForceID,omitempty" force:"Id,omitempty"`
-	Email           string            `json:"email,omitempty" force:"Email,omitempty"`
-	Phone           string            `json:"phone,omitempty" force:"Phone,omitempty"`
-	Fax             string            `json:"fax,omitempty" force:"Fax,omitempty"`
-	Title           string            `json:"title,omitempty" force:"Title,omitempty"`
-	Account         *AccountDTO       `json:"account,omitempty" force:"Account,omitempty"`
-	ContactRoles    []*ContactRoleDTO `json:"contactRoles,omitempty" force:"-"`
-	DefaultAccount  string            `json:"defaultAccount,omitempty" force:"Default_Account__c,omitempty"`
-	Status          string            `json:"status,omitempty" force:"SFDC_Contact_Status__c,omitempty"`
-	Currency        string            `json:"currency,omitempty" force:"CurrencyIsoCode"`
-	BBAuthID        string            `json:"bbAuthId,omitempty" force:"BBAuthID__c,omitempty"`
-	BBAuthEmail     string            `json:"bbAuthEmail,omitempty" force:"BBAuth_Email__c,omitempty"`
-	BBAuthFirstName string            `json:"bbAuthFirstName,omitempty" force:"BBAuth_First_Name__c,omitempty"`
-	BBAuthLastName  string            `json:"bbAuthLastName,omitempty" force:"BBAuth_Last_Name__c,omitempty"`
+	Salutation      string               `json:"salutation,omitempty" force:"Salutation,omitempty"`
+	FirstName       string               `json:"firstName,omitempty" force:"FirstName,omitempty"`
+	LastName        string               `json:"lastName,omitempty" force:"LastName,omitempty"`
+	SalesForceID    string               `json:"salesForceID,omitempty" force:"Id,omitempty"`
+	Email           string               `json:"email,omitempty" force:"Email,omitempty"`
+	Phone           string               `json:"phone,omitempty" force:"Phone,omitempty"`
+	Fax             string               `json:"fax,omitempty" force:"Fax,omitempty"`
+	Title           string               `json:"title,omitempty" force:"Title,omitempty"`
+	Account         *AccountDTO          `json:"account,omitempty" force:"Account,omitempty"`
+	ContactRoles    *ContactRolesWrapper `json:"contactRoles,omitempty" force:"Contact_Roles1__r,omitempty"`
+	DefaultAccount  string               `json:"defaultAccount,omitempty" force:"Default_Account__c,omitempty"`
+	Status          string               `json:"status,omitempty" force:"SFDC_Contact_Status__c,omitempty"`
+	Currency        string               `json:"currency,omitempty" force:"CurrencyIsoCode"`
+	BBAuthID        string               `json:"bbAuthId,omitempty" force:"BBAuthID__c,omitempty"`
+	BBAuthEmail     string               `json:"bbAuthEmail,omitempty" force:"BBAuth_Email__c,omitempty"`
+	BBAuthFirstName string               `json:"bbAuthFirstName,omitempty" force:"BBAuth_First_Name__c,omitempty"`
+	BBAuthLastName  string               `json:"bbAuthLastName,omitempty" force:"BBAuth_Last_Name__c,omitempty"`
+}
+
+//ContactRolesWrapper wraps a slice of ContactRoleDTO pointers so that the SFDC
+//unmarshaling process can build valid structures.
+type ContactRolesWrapper struct {
+	Roles []*ContactRoleDTO `json:"roles,omitempty" force:"records,omitempty"`
 }
 
 //ContactRoleDTO is a data transfer object for Contact Roles.

--- a/services/contactservice.go
+++ b/services/contactservice.go
@@ -25,22 +25,30 @@ type ContactQueryBuilder interface {
 //ContactDTO is a data transfer object for entities.Contact
 type ContactDTO struct {
 	//AccountName       string `json:"accountName,omitempty" force:"AccountName__c,omitempty"`
-	Salutation      string      `json:"salutation,omitempty" force:"Salutation,omitempty"`
-	FirstName       string      `json:"firstName,omitempty" force:"FirstName,omitempty"`
-	LastName        string      `json:"lastName,omitempty" force:"LastName,omitempty"`
-	SalesForceID    string      `json:"salesForceID,omitempty" force:"Id,omitempty"`
-	Email           string      `json:"email,omitempty" force:"Email,omitempty"`
-	Phone           string      `json:"phone,omitempty" force:"Phone,omitempty"`
-	Fax             string      `json:"fax,omitempty" force:"Fax,omitempty"`
-	Title           string      `json:"title,omitempty" force:"Title,omitempty"`
-	Account         *AccountDTO `json:"account,omitempty" force:"Account,omitempty"`
-	DefaultAccount  string      `json:"defaultAccount,omitempty" force:"Default_Account__c,omitempty"`
-	Status          string      `json:"status,omitempty" force:"SFDC_Contact_Status__c,omitempty"`
-	Currency        string      `json:"currency,omitempty" force:"CurrencyIsoCode"`
-	BBAuthID        string      `json:"bbAuthId,omitempty" force:"BBAuthID__c,omitempty"`
-	BBAuthEmail     string      `json:"bbAuthEmail,omitempty" force:"BBAuth_Email__c,omitempty"`
-	BBAuthFirstName string      `json:"bbAuthFirstName,omitempty" force:"BBAuth_First_Name__c,omitempty"`
-	BBAuthLastName  string      `json:"bbAuthLastName,omitempty" force:"BBAuth_Last_Name__c,omitempty"`
+	Salutation      string            `json:"salutation,omitempty" force:"Salutation,omitempty"`
+	FirstName       string            `json:"firstName,omitempty" force:"FirstName,omitempty"`
+	LastName        string            `json:"lastName,omitempty" force:"LastName,omitempty"`
+	SalesForceID    string            `json:"salesForceID,omitempty" force:"Id,omitempty"`
+	Email           string            `json:"email,omitempty" force:"Email,omitempty"`
+	Phone           string            `json:"phone,omitempty" force:"Phone,omitempty"`
+	Fax             string            `json:"fax,omitempty" force:"Fax,omitempty"`
+	Title           string            `json:"title,omitempty" force:"Title,omitempty"`
+	Account         *AccountDTO       `json:"account,omitempty" force:"Account,omitempty"`
+	ContactRoles    []*ContactRoleDTO `json:"contactRoles,omitempty" force:"-"`
+	DefaultAccount  string            `json:"defaultAccount,omitempty" force:"Default_Account__c,omitempty"`
+	Status          string            `json:"status,omitempty" force:"SFDC_Contact_Status__c,omitempty"`
+	Currency        string            `json:"currency,omitempty" force:"CurrencyIsoCode"`
+	BBAuthID        string            `json:"bbAuthId,omitempty" force:"BBAuthID__c,omitempty"`
+	BBAuthEmail     string            `json:"bbAuthEmail,omitempty" force:"BBAuth_Email__c,omitempty"`
+	BBAuthFirstName string            `json:"bbAuthFirstName,omitempty" force:"BBAuth_First_Name__c,omitempty"`
+	BBAuthLastName  string            `json:"bbAuthLastName,omitempty" force:"BBAuth_Last_Name__c,omitempty"`
+}
+
+//ContactRoleDTO is a data transfer object for Contact Roles.
+type ContactRoleDTO struct {
+	RoleType   string `json:"roleType,omitempty" force:"Role_Type__c,omitempty"`
+	RoleName   string `json:"roleName,omitempty" force:"Role_Name__c,omitempty"`
+	RoleStatus string `json:"roleStatus,omitempty" force:"Role_Status__c,omitempty"`
 }
 
 //ToEntity converts a ContactDTO into a Contact entity.

--- a/services/contactservices_test.go
+++ b/services/contactservices_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/blackbaudIT/webcore/Godeps/_workspace/src/github.com/smartystreets/goconvey/convey"
+	"github.com/blackbaudIT/webcore/entities"
 )
 
 var contactDTO = ContactDTO{
@@ -17,6 +18,7 @@ var contactDTO = ContactDTO{
 	Fax:             "(843)654-2566",
 	Title:           "Application Developer II",
 	Account:         &accountDTO,
+	ContactRoles:    &ContactRolesWrapper{Roles: []*ContactRoleDTO{&ContactRoleDTO{}}},
 	Status:          "Active",
 	Currency:        "USD - U.S. Dollar",
 	BBAuthID:        "32FBC72D-C0FE-4B50-B0F4-EDCEFD7B4DEF",
@@ -131,6 +133,17 @@ func TestConvertContactEntityToContactDTO(t *testing.T) {
 	})
 }
 
+func TestContactRoleToContactRoleDTO(t *testing.T) {
+	Convey("Given a valid ContactRole", t, func() {
+		contactRole := &entities.ContactRole{RoleName: "Test"}
+		Convey("When attempting to convert to a ContactRoleDTO", func() {
+			contactRoleDTO := ContactRoleToContactRoleDTO(contactRole)
+			Convey("Then a ContactDTO should be returned", func() {
+				So(contactRoleDTO, ShouldNotBeNil)
+			})
+		})
+	})
+}
 func TestNewContactService(t *testing.T) {
 	Convey("Given a valid ContactRepo", t, func() {
 		contactRepo := mockContactRepository{}


### PR DESCRIPTION
Queries for Contacts now return all of the roles related to that contact. 

I ended up adding a ContactRolesWrapper struct to contactservice.go that houses a slice of ContactRoleDTO pointers that are tagged with 'force:"records,omitempty"'. I then added a field to the ContactDTO called ContactRoles which is a pointer to a ContactRolesWrapper with the tag 'force:"Contact_Roles1__r"'. This allows go-force package to properly unmarshal the ContactRole data into something we can consume.

In the future it would be ideal to come up with a better solution for this since it lets too much of the SFDC repository leak into the service layer. Changing how we keep track of roles for contacts or modifying the go-force package to work in a way that's cleaner for these types of queries might be a direction we could go.